### PR TITLE
Added flake8 to check for Python linting issues

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,6 +85,9 @@ jobs:
           key: v1-sonarcloud-scanner-4.6.2.2472
           paths: /tmp/cache/scanner
 
+      - run:
+          name: flake8 lint tests
+          command: flake8 .
   dependency-check:
     docker:
       - image: cimg/python:3.8

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,7 +87,7 @@ jobs:
 
       - run:
           name: flake8 lint tests
-          command: flake8 .
+          command: flake8 --config .flake8
   dependency-check:
     docker:
       - image: cimg/python:3.8

--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,4 @@
+[flake8]
+max-line-lenght = 160
+ignore =
+    Z111  # not a real code, just placeholder for an example

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,3 +1,4 @@
 pytest==6.2.5
 pytest-cov==3.0.0
 safety==1.10.3
+flake8==4.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,4 +27,3 @@ pdfkit==0.6.1
 beautifulsoup4==4.7.1
 
 gunicorn==19.10.0
-flake8==3.6.0


### PR DESCRIPTION
This will add the flake8 lint test to the CircleCI test job.  

It has not been configured to ignore any of the legacy code issues so the job will fail if the PR is merged as-is.  If we would like to prevent the failed job, we can add the flake8 issue codes to the .flake8 config file to suppress them.